### PR TITLE
Circular dependency

### DIFF
--- a/HintTest.cabal
+++ b/HintTest.cabal
@@ -6,7 +6,6 @@ version:             0.1.0.0
 -- synopsis:            
 -- description:         
 -- license:             
-license-file:        LICENSE
 author:              Rob
 maintainer:          polygonhell@gmail.com
 -- copyright:           

--- a/HintTest.cabal
+++ b/HintTest.cabal
@@ -14,8 +14,9 @@ build-type:          Simple
 -- extra-source-files:  
 cabal-version:       >=1.10
 
-executable HintTest
-  main-is:             Main.hs
+library
+  exposed-modules:     Main
+                     , SomeType
   -- other-modules:       
   -- other-extensions:    
   build-depends:       base >=4.8 && <4.9,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -8,7 +8,7 @@ import Language.Haskell.Interpreter
 
 testHint :: Interpreter SomeType
 testHint = do
-  set [searchPath := ["plugin", "src"]]
+  set [searchPath := ["plugin"]]
   loadModules ["TestHint"]
   getLoadedModules >>= liftIO . print
   setTopLevelModules ["TestHint"]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -5,6 +5,7 @@ import SomeType
 import Data.List
 import Text.Printf
 import Language.Haskell.Interpreter
+import Language.Haskell.Interpreter.Unsafe
 
 testHint :: Interpreter SomeType
 testHint = do
@@ -27,7 +28,8 @@ errorString (WontCompile es) = intercalate "\n" (header : map unbox es)
 errorString e = show e
 
 main :: IO ()
-main = do r <- runInterpreter testHint
+          -- change this path to your sandbox as appropriate, or remove entirely if you installed HintTest globally.
+main = do r <- unsafeRunInterpreterWithArgs ["-package-db=.cabal-sandbox/x86_64-osx-ghc-7.10.2-packages.conf.d/"] testHint
           case r of
             Left err -> putStrLn $ errorString err
             Right fn -> do 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -27,9 +27,9 @@ errorString (WontCompile es) = intercalate "\n" (header : map unbox es)
     unbox (GhcError e) = e
 errorString e = show e
 
-main :: IO ()
-          -- change this path to your sandbox as appropriate, or remove entirely if you installed HintTest globally.
-main = do r <- unsafeRunInterpreterWithArgs ["-package-db=.cabal-sandbox/x86_64-osx-ghc-7.10.2-packages.conf.d/"] testHint
+main :: FilePath -> IO ()
+main sandbox = do
+          r <- unsafeRunInterpreterWithArgs ["-package-db=" ++ sandbox] testHint
           case r of
             Left err -> putStrLn $ errorString err
             Right fn -> do 

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+set -e
+
+cabal sandbox init
+cabal install
 SANDBOX="$(ls -d .cabal-sandbox/*.conf.d)"
 ghc -package-db="$SANDBOX" -e 'import Main' -e "main \"$SANDBOX\""

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ghc -package-db=.cabal-sandbox/x86_64-osx-ghc-7.10.2-packages.conf.d/ -e 'import Main' -e 'main'

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-ghc -package-db=.cabal-sandbox/x86_64-osx-ghc-7.10.2-packages.conf.d/ -e 'import Main' -e 'main'
+SANDBOX="$(ls -d .cabal-sandbox/*.conf.d)"
+ghc -package-db="$SANDBOX" -e 'import Main' -e "main \"$SANDBOX\""


### PR DESCRIPTION
A demonstration that it is possible to expose types from the code running hint to the code executed by hint without factoring those types into a separate package.
